### PR TITLE
Remove ID param, PostModel.php automatically fills this

### DIFF
--- a/.phpstorm.meta.php/PostModel.php
+++ b/.phpstorm.meta.php/PostModel.php
@@ -9,6 +9,6 @@ namespace OffbeatWP\Content\Post {
     class PostModel {
         public function getField(string $selector, bool $format_value = true): mixed;
         public function getFieldObject(string $selector, bool $format_value = true): array;
-        public function updateField(string $selector, bool $post_id = true): bool;
+        public function updateField(string $selector, mixed $value = false): bool;
     }
 }

--- a/.phpstorm.meta.php/PostModel.php
+++ b/.phpstorm.meta.php/PostModel.php
@@ -7,8 +7,8 @@ namespace  {
 
 namespace OffbeatWP\Content\Post {
     class PostModel {
-        public function getField(string $selector, mixed $post_id = false, bool $format_value = true): mixed;
-        public function getFieldObject(string $selector, mixed $post_id = false, bool $format_value = true): array;
-        public function updateField(string $selector, mixed $value = false, bool $post_id = true): bool;
+        public function getField(string $selector, bool $format_value = true): mixed;
+        public function getFieldObject(string $selector, bool $format_value = true): array;
+        public function updateField(string $selector, bool $post_id = true): bool;
     }
 }

--- a/.phpstorm.meta.php/TermModel.php
+++ b/.phpstorm.meta.php/TermModel.php
@@ -7,6 +7,6 @@ namespace  {
 
 namespace OffbeatWP\Content\Taxonomy {
     class TermModel {
-        public function getField(string $selector, mixed $post_id = false, bool $format_value = true): mixed;
+        public function getField(string $selector, bool $format_value = true): mixed;
     }
 }


### PR DESCRIPTION
Type-hinted params now want the params that their macros need rather than the params that the original functions need.