### PR TITLE
Prefix uuid with 'ob' to ensure the final value is a valid css class

### DIFF
--- a/src/Fields/HiddenUniqueIdField.php
+++ b/src/Fields/HiddenUniqueIdField.php
@@ -39,6 +39,6 @@ class HiddenUniqueIdField extends acf_field
             return $value;
         }
 
-        return uniqid();
+        return uniqid('ob', false);
     }
 }

--- a/src/Hooks/AcfTermAttributeFilter.php
+++ b/src/Hooks/AcfTermAttributeFilter.php
@@ -6,10 +6,6 @@ use OffbeatWP\Hooks\AbstractFilter;
 
 class AcfTermAttributeFilter extends AbstractFilter {
     public function filter($value, string $name, TermModel $model) {
-        if (!empty($fieldValue = get_field($name, $model->wpTerm))) {
-            return $fieldValue;
-        }
-
-        return $value;
+        return get_field($name, $model->wpTerm) ?: $value;
     }
 }


### PR DESCRIPTION
CSS classes cannot start with numbers, but PHP's randomly generated UID's can.
Adding 'ob' as prefix fixes this.